### PR TITLE
Update pfcpiface for End Marker handling

### DIFF
--- a/pfcpiface/conn.go
+++ b/pfcpiface/conn.go
@@ -56,7 +56,7 @@ type PFCPConn struct {
 	store SessionsStore
 
 	nodeID nodeID
-	upf    *upf
+	upf    *Upf
 	// channel to signal PFCPNode on exit
 	done     chan<- string
 	shutdown chan struct{}

--- a/pfcpiface/datapath.go
+++ b/pfcpiface/datapath.go
@@ -9,16 +9,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type upfMsgType int
+type UpfMsgType int
 
 const (
-	upfMsgTypeAdd upfMsgType = iota
+	upfMsgTypeAdd UpfMsgType = iota
 	upfMsgTypeMod
 	upfMsgTypeDel
 	upfMsgTypeClear
 )
 
-func (u upfMsgType) String() string {
+func (u UpfMsgType) String() string {
 	if u == upfMsgTypeAdd {
 		return "add"
 	} else if u == upfMsgTypeMod {
@@ -32,11 +32,11 @@ func (u upfMsgType) String() string {
 	}
 }
 
-type datapath interface {
+type Datapath interface {
 	/* Close any pending sessions */
 	Exit()
 	/* setup internal parameters and channel with datapath */
-	SetUpfInfo(u *upf, conf *Conf)
+	SetUpfInfo(u *Upf, conf *Conf)
 	/* set up slice info */
 	AddSliceInfo(sliceInfo *SliceInfo) error
 	/* write endMarker to datapath */
@@ -45,10 +45,10 @@ type datapath interface {
 	// "master" function to send create/update/delete messages to UPF.
 	// "new" PacketForwardingRules are only used for update messages to UPF.
 	// TODO: we should have better CRUD API, with a single function per message type.
-	SendMsgToUPF(method upfMsgType, all PacketForwardingRules, new PacketForwardingRules) uint8
+	SendMsgToUPF(method UpfMsgType, all PacketForwardingRules, new PacketForwardingRules) uint8
 	/* check of communication channel to datapath is setup */
 	IsConnected(accessIP *net.IP) bool
-	SummaryLatencyJitter(uc *upfCollector, ch chan<- prometheus.Metric)
-	PortStats(uc *upfCollector, ch chan<- prometheus.Metric)
+	SummaryLatencyJitter(uc *UpfCollector, ch chan<- prometheus.Metric)
+	PortStats(uc *UpfCollector, ch chan<- prometheus.Metric)
 	SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) error
 }

--- a/pfcpiface/datapath.go
+++ b/pfcpiface/datapath.go
@@ -40,7 +40,7 @@ type Datapath interface {
 	/* set up slice info */
 	AddSliceInfo(sliceInfo *SliceInfo) error
 	/* write endMarker to datapath */
-	SendEndMarkers(endMarkerList *[][]byte) error
+	SendEndMarkers(endMarkerList *[]EndMarker) error
 	/* write pdr/far/qer to datapath */
 	// "master" function to send create/update/delete messages to UPF.
 	// "new" PacketForwardingRules are only used for update messages to UPF.

--- a/pfcpiface/ebpf.go
+++ b/pfcpiface/ebpf.go
@@ -70,7 +70,7 @@ func (d *ebpf) PortStats(uc *UpfCollector, ch chan<- prometheus.Metric) {
 	panic("Not implemented")
 }
 
-func (d *ebpf) SendEndMarkers(endMarkerList *[][]byte) error {
+func (d *ebpf) SendEndMarkers(endMarkerList *[]EndMarker) error {
 	panic("Not implemented")
 }
 

--- a/pfcpiface/ebpf.go
+++ b/pfcpiface/ebpf.go
@@ -9,23 +9,18 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/wmnsk/go-pfcp/ie"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 )
 
 type ebpf struct {
 	conn             *grpc.ClientConn
-	endMarkerSocket  net.Conn
-	notifyBessSocket net.Conn
-	endMarkerChan    chan []byte
 }
 
 func (d *ebpf) IsConnected(accessIP *net.IP) bool {
-	if (d.conn == nil) || (d.conn.GetState() != connectivity.Ready) {
-		return false
-	}
-
+	// TODO(ardzoht): Add connection check for server to DP service
+	// Defaulting to true for now to test with PFCPsim
 	return true
 }
 
@@ -34,35 +29,55 @@ func (d *ebpf) Exit() {
 }
 
 // SetUpfInfo is only called at pfcp-agent's startup
-func (d *ebpf) SetUpfInfo(u *upf, conf *Conf) {
+func (d *ebpf) SetUpfInfo(u *Upf, conf *Conf) {
 	log.Println("Setting UPF config...")
 }
 
 func (d *ebpf) SendMsgToUPF(
-	method upfMsgType, rules PacketForwardingRules, updated PacketForwardingRules) uint8 {
-	panic("Not implemented")
+	method UpfMsgType, rules PacketForwardingRules, updated PacketForwardingRules) uint8 {
+	var cause uint8 = ie.CauseRequestAccepted
+
+	pdrs := rules.pdrs
+	fars := rules.fars
+	qers := rules.qers
+
+	if method == upfMsgTypeMod {
+		pdrs = updated.pdrs
+		fars = updated.fars
+		qers = updated.qers
+	}
+
+	for _, pdr := range pdrs {
+		log.Traceln(method, pdr)
+	}
+
+	for _, far := range fars {
+		log.Traceln(method, far)
+	}
+
+	for _, qer := range qers {
+		log.Traceln(method, qer)
+	}
+
+	return cause
 }
 
 func (d *ebpf) AddSliceInfo(sliceInfo *SliceInfo) error {
 	panic("Not implemented")
 }
 
-func (d *ebpf) PortStats(uc *upfCollector, ch chan<- prometheus.Metric) {
+func (d *ebpf) PortStats(uc *UpfCollector, ch chan<- prometheus.Metric) {
 	panic("Not implemented")
 }
 
 func (d *ebpf) SendEndMarkers(endMarkerList *[][]byte) error {
-	for _, eMarker := range *endMarkerList {
-		d.endMarkerChan <- eMarker
-	}
-
-	return nil
+	panic("Not implemented")
 }
 
 func (d *ebpf) SessionStats(pc *PfcpNodeCollector, ch chan<- prometheus.Metric) (err error) {
 	panic("Not implemented")
 }
 
-func (d *ebpf) SummaryLatencyJitter(uc *upfCollector, ch chan<- prometheus.Metric) {
+func (d *ebpf) SummaryLatencyJitter(uc *UpfCollector, ch chan<- prometheus.Metric) {
 	panic("Not implemented")
 }

--- a/pfcpiface/grpcsim.go
+++ b/pfcpiface/grpcsim.go
@@ -68,7 +68,7 @@ func (s simMode) enable() bool {
 	return s != simModeDisable
 }
 
-func (u *upf) sim(mode simMode, s *SimModeInfo) {
+func (u *Upf) sim(mode simMode, s *SimModeInfo) {
 	log.Infoln(simulate.String(), "sessions:", s.MaxSessions)
 
 	start := time.Now()

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -218,7 +218,7 @@ func (pConn *PFCPConn) handleSessionModificationRequest(msg message.Message) (me
 	addPDRs := make([]pdr, 0, MaxItems)
 	addFARs := make([]far, 0, MaxItems)
 	addQERs := make([]qer, 0, MaxItems)
-	endMarkerList := make([][]byte, 0, MaxItems)
+	endMarkerList := make([]EndMarker, 0, MaxItems)
 
 	for _, cPDR := range smreq.CreatePDR {
 		var p pdr

--- a/pfcpiface/node.go
+++ b/pfcpiface/node.go
@@ -28,13 +28,13 @@ type PFCPNode struct {
 	// map of existing connections
 	pConns sync.Map
 	// upf
-	upf *upf
+	upf *Upf
 	// metrics for PFCP messages and sessions
 	metrics metrics.InstrumentPFCP
 }
 
 // NewPFCPNode create a new PFCPNode listening on local address.
-func NewPFCPNode(upf *upf) *PFCPNode {
+func NewPFCPNode(upf *Upf) *PFCPNode {
 	conn, err := reuse.ListenPacket("udp", ":"+PFCPPort)
 	if err != nil {
 		log.Fatalln("ListenUDP failed", err)

--- a/pfcpiface/parse_far.go
+++ b/pfcpiface/parse_far.go
@@ -65,7 +65,7 @@ func (f *far) Forwards() bool {
 	return f.applyAction&ActionForward != 0
 }
 
-func (f *far) parseFAR(farIE *ie.IE, fseid uint64, upf *upf, op operation) error {
+func (f *far) parseFAR(farIE *ie.IE, fseid uint64, upf *Upf, op operation) error {
 	f.fseID = (fseid)
 
 	farID, err := farIE.FARID()

--- a/pfcpiface/pfcpiface.go
+++ b/pfcpiface/pfcpiface.go
@@ -29,13 +29,13 @@ type PFCPIface struct {
 	conf Conf
 
 	node *PFCPNode
-	fp   datapath
-	upf  *upf
+	fp   Datapath
+	upf  *Upf
 
 	httpSrv      *http.Server
 	httpEndpoint string
 
-	uc *upfCollector
+	uc *UpfCollector
 	nc *PfcpNodeCollector
 
 	mu sync.Mutex
@@ -47,6 +47,25 @@ func NewPFCPIface(conf Conf) *PFCPIface {
 	}
 
 	pfcpIface.fp = &ebpf{}
+
+	httpPort := "8080"
+	if conf.CPIface.HTTPPort != "" {
+		httpPort = conf.CPIface.HTTPPort
+	}
+
+	pfcpIface.httpEndpoint = ":" + httpPort
+
+	pfcpIface.upf = NewUPF(&conf, pfcpIface.fp)
+
+	return pfcpIface
+}
+
+func NewPFCPIfaceWithDp(conf Conf, dp Datapath) *PFCPIface {
+	pfcpIface := &PFCPIface{
+		conf: conf,
+	}
+
+	pfcpIface.fp = dp
 
 	httpPort := "8080"
 	if conf.CPIface.HTTPPort != "" {

--- a/pfcpiface/telemetry.go
+++ b/pfcpiface/telemetry.go
@@ -25,8 +25,8 @@ func makeBuckets(values []uint64) map[float64]float64 {
 	return buckets
 }
 
-// upfCollector provides all UPF metrics.
-type upfCollector struct {
+// UpfCollector provides all UPF metrics.
+type UpfCollector struct {
 	packets *prometheus.Desc
 	bytes   *prometheus.Desc
 	dropped *prometheus.Desc
@@ -34,11 +34,11 @@ type upfCollector struct {
 	latency *prometheus.Desc
 	jitter  *prometheus.Desc
 
-	upf *upf
+	upf *Upf
 }
 
-func newUpfCollector(upf *upf) *upfCollector {
-	return &upfCollector{
+func newUpfCollector(upf *Upf) *UpfCollector {
+	return &UpfCollector{
 		packets: prometheus.NewDesc(prometheus.BuildFQName("upf", "packets", "count"),
 			"Shows the number of packets received by the UPF port",
 			[]string{"iface", "dir"}, nil,
@@ -64,7 +64,7 @@ func newUpfCollector(upf *upf) *upfCollector {
 }
 
 // Describe writes all descriptors to the prometheus desc channel.
-func (uc *upfCollector) Describe(ch chan<- *prometheus.Desc) {
+func (uc *UpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- uc.packets
 	ch <- uc.bytes
 	ch <- uc.dropped
@@ -74,17 +74,17 @@ func (uc *upfCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect writes all metrics to prometheus metric channel.
-func (uc *upfCollector) Collect(ch chan<- prometheus.Metric) {
+func (uc *UpfCollector) Collect(ch chan<- prometheus.Metric) {
 	uc.summaryLatencyJitter(ch)
 	uc.portStats(ch)
 }
 
-func (uc *upfCollector) portStats(ch chan<- prometheus.Metric) {
+func (uc *UpfCollector) portStats(ch chan<- prometheus.Metric) {
 	// When operating in sim mode there are no BESS ports
 	uc.upf.PortStats(uc, ch)
 }
 
-func (uc *upfCollector) summaryLatencyJitter(ch chan<- prometheus.Metric) {
+func (uc *UpfCollector) summaryLatencyJitter(ch chan<- prometheus.Metric) {
 	uc.upf.SummaryLatencyJitter(uc, ch)
 }
 
@@ -143,7 +143,7 @@ func (col PfcpNodeCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func setupProm(mux *http.ServeMux, upf *upf, node *PFCPNode) (*upfCollector, *PfcpNodeCollector, error) {
+func setupProm(mux *http.ServeMux, upf *Upf, node *PFCPNode) (*UpfCollector, *PfcpNodeCollector, error) {
 	uc := newUpfCollector(upf)
 	if err := prometheus.Register(uc); err != nil {
 		return nil, nil, err
@@ -159,9 +159,9 @@ func setupProm(mux *http.ServeMux, upf *upf, node *PFCPNode) (*upfCollector, *Pf
 	return uc, nc, nil
 }
 
-func clearProm(uc *upfCollector, nc *PfcpNodeCollector) {
+func clearProm(uc *UpfCollector, nc *PfcpNodeCollector) {
 	if ok := prometheus.Unregister(uc); !ok {
-		log.Warnln("Failed to unregister upfCollector")
+		log.Warnln("Failed to unregister UpfCollector")
 	}
 
 	if ok := prometheus.Unregister(nc); !ok {

--- a/pfcpiface/up4.go
+++ b/pfcpiface/up4.go
@@ -222,14 +222,14 @@ func (up4 *UP4) AddSliceInfo(sliceInfo *SliceInfo) error {
 	return nil
 }
 
-func (up4 *UP4) SummaryLatencyJitter(uc *upfCollector, ch chan<- prometheus.Metric) {
+func (up4 *UP4) SummaryLatencyJitter(uc *UpfCollector, ch chan<- prometheus.Metric) {
 }
 
 func (up4 *UP4) SessionStats(*PfcpNodeCollector, chan<- prometheus.Metric) error {
 	return nil
 }
 
-func (up4 *UP4) PortStats(uc *upfCollector, ch chan<- prometheus.Metric) {
+func (up4 *UP4) PortStats(uc *UpfCollector, ch chan<- prometheus.Metric) {
 }
 
 func (up4 *UP4) initCounter(counterID uint8, name string, counterSize uint64) {
@@ -402,7 +402,7 @@ func (up4 *UP4) setConnectedStatus(status bool) {
 }
 
 // TODO: rename it to initUPF()
-func (up4 *UP4) SetUpfInfo(u *upf, conf *Conf) {
+func (up4 *UP4) SetUpfInfo(u *Upf, conf *Conf) {
 	log.Println("SetUpfInfo UP4")
 
 	up4.conf = conf.P4rtcIface
@@ -1529,7 +1529,7 @@ func (up4 *UP4) sendDelete(deleted PacketForwardingRules) error {
 	return nil
 }
 
-func (up4 *UP4) SendMsgToUPF(method upfMsgType, all PacketForwardingRules, updated PacketForwardingRules) uint8 {
+func (up4 *UP4) SendMsgToUPF(method UpfMsgType, all PacketForwardingRules, updated PacketForwardingRules) uint8 {
 	err := up4.tryConnect()
 	if err != nil {
 		log.Error("UP4 server not connected")

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -34,7 +34,7 @@ type UeResource struct {
 	dnn  string
 }
 
-type upf struct {
+type Upf struct {
 	enableUeIPAlloc   bool
 	enableEndMarker   bool
 	enableFlowMeasure bool
@@ -51,7 +51,7 @@ type upf struct {
 	sliceInfo         *SliceInfo
 	readTimeout       time.Duration
 
-	datapath
+	Datapath
 	maxReqRetries uint8
 	respTimeout   time.Duration
 	enableHBTimer bool
@@ -74,21 +74,21 @@ const (
 	n9 = 0x2
 )
 
-func (u *upf) isConnected() bool {
-	return u.datapath.IsConnected(&u.accessIP)
+func (u *Upf) isConnected() bool {
+	return u.Datapath.IsConnected(&u.accessIP)
 }
 
-func (u *upf) addSliceInfo(sliceInfo *SliceInfo) error {
+func (u *Upf) addSliceInfo(sliceInfo *SliceInfo) error {
 	if sliceInfo == nil {
 		return ErrInvalidArgument("sliceInfo", sliceInfo)
 	}
 
 	u.sliceInfo = sliceInfo
 
-	return u.datapath.AddSliceInfo(sliceInfo)
+	return u.Datapath.AddSliceInfo(sliceInfo)
 }
 
-func NewUPF(conf *Conf, fp datapath) *upf {
+func NewUPF(conf *Conf, fp Datapath) *Upf {
 	var (
 		err    error
 		nodeID string
@@ -112,7 +112,7 @@ func NewUPF(conf *Conf, fp datapath) *upf {
 		nodeID = hosts[0]
 	}
 
-	u := &upf{
+	u := &Upf{
 		enableUeIPAlloc:   conf.CPIface.EnableUeIPAlloc,
 		enableEndMarker:   conf.EnableEndMarker,
 		enableFlowMeasure: conf.EnableFlowMeasure,
@@ -120,7 +120,7 @@ func NewUPF(conf *Conf, fp datapath) *upf {
 		coreIface:         conf.CoreIface.IfName,
 		ippoolCidr:        conf.CPIface.UEIPPool,
 		nodeID:            nodeID,
-		datapath:          fp,
+		Datapath:          fp,
 		dnn:               conf.CPIface.Dnn,
 		peers:             conf.CPIface.Peers,
 		reportNotifyChan:  make(chan uint64, 1024),
@@ -173,7 +173,7 @@ func NewUPF(conf *Conf, fp datapath) *upf {
 		}
 	}
 
-	u.datapath.SetUpfInfo(u, conf)
+	u.Datapath.SetUpfInfo(u, conf)
 
 	return u
 }

--- a/pfcpiface/web_service.go
+++ b/pfcpiface/web_service.go
@@ -42,10 +42,10 @@ type UeResInfo struct {
 }
 
 type ConfigHandler struct {
-	upf *upf
+	upf *Upf
 }
 
-func setupConfigHandler(mux *http.ServeMux, upf *upf) {
+func setupConfigHandler(mux *http.ServeMux, upf *Upf) {
 	cfgHandler := ConfigHandler{upf: upf}
 	mux.Handle("/v1/config/network-slices", &cfgHandler)
 }
@@ -129,7 +129,7 @@ func calculateBitRates(mbr uint64, rate string) uint64 {
 	}
 }
 
-func handleSliceConfig(nwSlice *NetworkSlice, upf *upf) {
+func handleSliceConfig(nwSlice *NetworkSlice, upf *Upf) {
 	log.Infoln("handle slice config : ", nwSlice.SliceName)
 
 	ulMbr := calculateBitRates(nwSlice.SliceQos.UplinkMbr,


### PR DESCRIPTION
- Export private classes in the pfcpiface to the gtp server
- Update the End Marker logic. Now the End Marker will be generated by the gtp server rather than pfcp.