### PR TITLE
Making ReportNotifyChan variable public for Downlink Data Report (DDR)

### DIFF
--- a/pfcpiface/node.go
+++ b/pfcpiface/node.go
@@ -120,7 +120,7 @@ func (node *PFCPNode) Serve() {
 
 	for !shutdown {
 		select {
-		case fseid := <-node.upf.reportNotifyChan:
+		case fseid := <-node.upf.ReportNotifyChan:
 			// TODO: Logic to distinguish PFCPConn based on SEID
 			node.pConns.Range(func(key, value interface{}) bool {
 				pConn := value.(*PFCPConn)

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -46,7 +46,7 @@ type Upf struct {
 	ippool            *IPPool
 	peers             []string
 	dnn               string
-	reportNotifyChan  chan uint64
+	ReportNotifyChan  chan uint64
 	sliceInfo         *SliceInfo
 	readTimeout       time.Duration
 
@@ -122,7 +122,7 @@ func NewUPF(conf *Conf, fp Datapath) *Upf {
 		Datapath:          fp,
 		dnn:               conf.CPIface.Dnn,
 		peers:             conf.CPIface.Peers,
-		reportNotifyChan:  make(chan uint64, 1024),
+		ReportNotifyChan:  make(chan uint64, 1024),
 		maxReqRetries:     conf.MaxReqRetries,
 		enableHBTimer:     conf.EnableHBTimer,
 		readTimeout:       time.Second * time.Duration(conf.ReadTimeout),


### PR DESCRIPTION
Making ReportNotifyChan variable public. Then the Downlink Data Report (DDR) could be triggered in the GTP-U server.