### PR TITLE
Quick fix for bit checking

### DIFF
--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -38,7 +38,7 @@ func has2ndBit(f uint8) bool {
 }
 
 func has5thBit(f uint8) bool {
-	return (f & 0x010) == 1
+	return (f&0x010)>>4 == 1
 }
 
 func inc(ip net.IP) {


### PR DESCRIPTION
Quick fix. This code is used at 
- https://github.com/omec-project/upf/blob/4ba94ce96560e25f492474106e5979a0cd408f9e/pfcpiface/parse_pdr.go#L294
- https://github.com/omec-project/upf/blob/4ba94ce96560e25f492474106e5979a0cd408f9e/pfcpiface/parse_pdr.go#L339

Currently this code is checking nothing and always returns false. We should be careful though, and test our system accordingly to see  the system behaviour is still correct after this fix. Basically, double check if [this logic](https://github.com/omec-project/upf/blob/4ba94ce96560e25f492474106e5979a0cd408f9e/pfcpiface/parse_pdr.go#L295) is still correct.

---

Actually, there are already identical implementations https://github.com/wmnsk/go-pfcp/blob/d8ee06676c09f1d4f6049694fadf72cf884371d9/ie/misc.go, and probably simply using these utils could suffice the needs.