### PR TITLE
Adding TEID alloc support and bidirectional SDF into pfcpiface

### DIFF
--- a/pfcpiface/id_allocator.go
+++ b/pfcpiface/id_allocator.go
@@ -68,4 +68,3 @@ func (idAllocator *IDAllocator) updateOffset() {
 	idAllocator.offset++
 	idAllocator.offset = idAllocator.offset % idAllocator.valueRange
 }
-

--- a/pfcpiface/id_allocator.go
+++ b/pfcpiface/id_allocator.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Intel Corporation
+package pfcpiface
+
+import (
+	"errors"
+	"sync"
+)
+
+type IDAllocator struct {
+	lock       sync.Mutex
+	minValue   uint32
+	maxValue   uint32
+	valueRange uint32
+	offset     uint32
+	usedMap    map[uint32]bool
+}
+
+// NewIDAllocator with minValue and maxValue.
+func NewIDAllocator(minValue, maxValue uint32) *IDAllocator {
+	idAllocator := &IDAllocator{}
+	idAllocator.init(minValue, maxValue)
+	return idAllocator
+}
+
+func (idAllocator *IDAllocator) init(minValue, maxValue uint32) {
+	idAllocator.offset = 0
+	idAllocator.minValue = minValue
+	idAllocator.maxValue = maxValue
+	idAllocator.valueRange = maxValue - minValue + 1
+	idAllocator.usedMap = make(map[uint32]bool)
+}
+
+// Allocate and return an id in range [minValue, maxValue]
+func (idAllocator *IDAllocator) Allocate() (uint32, error) {
+	idAllocator.lock.Lock()
+	defer idAllocator.lock.Unlock()
+
+	offsetBegin := idAllocator.offset
+	for {
+		if _, ok := idAllocator.usedMap[idAllocator.offset]; ok {
+			idAllocator.updateOffset()
+
+			if idAllocator.offset == offsetBegin {
+				return 0, errors.New("No available value range to allocate id")
+			}
+		} else {
+			break
+		}
+	}
+	idAllocator.usedMap[idAllocator.offset] = true
+	id := idAllocator.offset + idAllocator.minValue
+	idAllocator.updateOffset()
+	return id, nil
+}
+
+// Free releases an already allocated ID
+func (idAllocator *IDAllocator) Free(id uint32) {
+	if id < idAllocator.minValue || id > idAllocator.maxValue {
+		return
+	}
+	idAllocator.lock.Lock()
+	defer idAllocator.lock.Unlock()
+	delete(idAllocator.usedMap, id-idAllocator.minValue)
+}
+
+func (idAllocator *IDAllocator) updateOffset() {
+	idAllocator.offset++
+	idAllocator.offset = idAllocator.offset % idAllocator.valueRange
+}
+

--- a/pfcpiface/id_allocator_test.go
+++ b/pfcpiface/id_allocator_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2021 Intel Corporation
+package pfcpiface
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestAllocate(t *testing.T) {
+	testCases := []struct {
+		minValue uint32
+		maxValue uint32
+	}{
+		{1, 200},
+		{11, 5000},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("minValue: %d, maxValue: %d", testCase.minValue, testCase.maxValue), func(t *testing.T) {
+			idGenerator := NewIDAllocator(testCase.minValue, testCase.maxValue)
+
+			for i := testCase.minValue; i <= testCase.maxValue; i++ {
+				id, err := idGenerator.Allocate()
+				if id != i {
+					t.Errorf("expected id: %d, output id: %d", i, id)
+					t.FailNow()
+				} else if err != nil {
+					t.Error(err)
+					t.FailNow()
+				}
+			}
+
+			for i := testCase.minValue; i <= testCase.maxValue; i++ {
+				idGenerator.Free(i)
+			}
+		})
+	}
+}
+
+func TestAllocatorConcurrency(t *testing.T) {
+	var usedMap sync.Map
+
+	idGenerator := NewIDAllocator(1, 50000)
+
+	wg := sync.WaitGroup{}
+	for routineID := 1; routineID <= 10; routineID++ {
+		wg.Add(1)
+		go func(routineID int) {
+			for i := 0; i < 1000; i++ {
+				id, err := idGenerator.Allocate()
+				if err != nil {
+					t.Errorf("idGenerator.Allocate fail: %+v", err)
+				}
+				if value, ok := usedMap.Load(id); ok {
+					t.Errorf("ID %d has been allocated at routine[%d], concurrent test failed", id, value)
+				} else {
+					usedMap.Store(id, routineID)
+				}
+			}
+			usedMap.Range(func(key, value interface{}) bool {
+				id := key.(uint32)
+				idGenerator.Free(id)
+				return true
+			})
+			wg.Done()
+		}(routineID)
+	}
+	wg.Wait()
+}
+
+func TestTriggerNoSpaceToAllocateError(t *testing.T) {
+	testCases := []struct {
+		minValue uint32
+		maxValue uint32
+	}{
+		{1, 10},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("minValue: %d, maxValue: %d", testCase.minValue, testCase.maxValue), func(t *testing.T) {
+			valueRange := int(testCase.maxValue - testCase.minValue + 1)
+			idGenerator := NewIDAllocator(testCase.minValue, testCase.maxValue)
+
+			for i := 0; i < valueRange; i++ {
+				_, err := idGenerator.Allocate()
+				if err != nil {
+					t.Error(err)
+					t.FailNow()
+				}
+			}
+
+			_, err := idGenerator.Allocate()
+			if err == nil {
+				t.Error("expect return error, but error is nil")
+				t.FailNow()
+			}
+		})
+	}
+}

--- a/pfcpiface/id_allocator_test.go
+++ b/pfcpiface/id_allocator_test.go
@@ -84,7 +84,9 @@ func TestTriggerNoSpaceToAllocateError(t *testing.T) {
 			idGenerator := NewIDAllocator(testCase.minValue, testCase.maxValue)
 
 			for i := 0; i < valueRange; i++ {
-				_, err := idGenerator.Allocate()
+				p, err := idGenerator.Allocate()
+				fmt.Sprint(p)
+
 				if err != nil {
 					t.Error(err)
 					t.FailNow()

--- a/pfcpiface/messages_conn.go
+++ b/pfcpiface/messages_conn.go
@@ -102,6 +102,9 @@ func (pConn *PFCPConn) associationIEs() []*ie.IE {
 
 	features := make([]uint8, 4)
 
+	// FTUP support
+	setTeidAllocFeature(features...)
+
 	if upf.enableUeIPAlloc {
 		setUeipFeature(features...)
 	}

--- a/pfcpiface/messages_session.go
+++ b/pfcpiface/messages_session.go
@@ -612,4 +612,3 @@ func (pConn *PFCPConn) handleSessionReportResponse(msg message.Message) error {
 
 	return nil
 }
-

--- a/pfcpiface/parse_pdr.go
+++ b/pfcpiface/parse_pdr.go
@@ -713,4 +713,3 @@ func (p *Pdr) parsePDR(ie1 *ie.IE, appPFDs map[string]appPFD, ippool *IPPool, up
 
 	return nil
 }
-

--- a/pfcpiface/parse_pdr.go
+++ b/pfcpiface/parse_pdr.go
@@ -328,9 +328,9 @@ func allocateTEID(p *Pdr, upf *Upf) error {
 
 	switch p.SrcIface {
 	case ie.SrcInterfaceAccess:
-		p.TunnelIP4Dst = ip2int(upf.CoreIP)
-	case ie.SrcInterfaceCore:
 		p.TunnelIP4Dst = ip2int(upf.AccessIP)
+	case ie.SrcInterfaceCore:
+		p.TunnelIP4Dst = ip2int(upf.CoreIP)
 	}
 	p.TunnelTEIDMask = 0xFFFFFFFF
 	p.TunnelIP4DstMask = 0xFFFFFFFF

--- a/pfcpiface/parse_pdr.go
+++ b/pfcpiface/parse_pdr.go
@@ -328,10 +328,10 @@ func allocateTEID(p *Pdr, upf *Upf) error {
 	}
 
 	switch p.SrcIface {
-	case ie.SrcInterfaceAccess:
-		p.TunnelIP4Dst = ip2int(upf.AccessIP)
-	case ie.SrcInterfaceCore:
+	case access:
 		p.TunnelIP4Dst = ip2int(upf.CoreIP)
+	case core:
+		p.TunnelIP4Dst = ip2int(upf.AccessIP)
 	}
 	p.TunnelTEIDMask = 0xFFFFFFFF
 	p.TunnelIP4DstMask = 0xFFFFFFFF
@@ -736,4 +736,3 @@ func (p *Pdr) parsePDR(ie1 *ie.IE, appPFDs map[string]appPFD, ippool *IPPool, up
 
 	return nil
 }
-

--- a/pfcpiface/parse_pdr.go
+++ b/pfcpiface/parse_pdr.go
@@ -329,9 +329,9 @@ func allocateTEID(p *Pdr, upf *Upf) error {
 
 	switch p.SrcIface {
 	case access:
-		p.TunnelIP4Dst = ip2int(upf.CoreIP)
-	case core:
 		p.TunnelIP4Dst = ip2int(upf.AccessIP)
+	case core:
+		p.TunnelIP4Dst = ip2int(upf.CoreIP)
 	}
 	p.TunnelTEIDMask = 0xFFFFFFFF
 	p.TunnelIP4DstMask = 0xFFFFFFFF

--- a/pfcpiface/parse_pdr_test.go
+++ b/pfcpiface/parse_pdr_test.go
@@ -29,6 +29,7 @@ func Test_parsePDR(t *testing.T) {
 	qerID := uint32(4)
 	farID := uint32(2)
 	teid := uint32(1234)
+	upf := &Upf{}
 
 	for _, scenario := range []pdrTestCase{
 		{
@@ -121,7 +122,9 @@ func Test_parsePDR(t *testing.T) {
 			mockPDR := &Pdr{}
 			mockIPPool, _ := NewIPPool("10.0.0.0")
 
-			err := mockPDR.parsePDR(scenario.input, FSEID, mockMapPFD, mockIPPool)
+			session := &PFCPSession{localSEID: 1}
+
+			err := mockPDR.parsePDR(scenario.input, mockMapPFD, mockIPPool, upf, session)
 			require.NoError(t, err)
 
 			assert.Equal(t, mockPDR, scenario.expected)
@@ -131,6 +134,7 @@ func Test_parsePDR(t *testing.T) {
 
 func TestParsePDRShouldError(t *testing.T) {
 	var FSEID uint64 = 100
+	upf := &Upf{}
 
 	for _, scenario := range []pdrTestCase{
 		{
@@ -160,7 +164,9 @@ func TestParsePDRShouldError(t *testing.T) {
 			mockPDR := &Pdr{}
 			mockIPPool, _ := NewIPPool("10.0.0.0")
 
-			err := mockPDR.parsePDR(scenario.input, FSEID, mockMapPFD, mockIPPool)
+			session := &PFCPSession{localSEID: 1}
+
+			err := mockPDR.parsePDR(scenario.input, mockMapPFD, mockIPPool, upf, session)
 			require.Error(t, err)
 
 			assert.Equal(t, scenario.expected, mockPDR)
@@ -710,7 +716,10 @@ func Test_pdr_parsePDI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Pdr{}
-			if err := p.parsePDI(tt.args.pdiIEs, tt.args.appPFDs, tt.args.ippool); (err != nil) != tt.wantErr {
+			upf := &Upf{}
+			session := &PFCPSession{localSEID: 1}
+
+			if err := p.parsePDI(tt.args.pdiIEs, tt.args.appPFDs, tt.args.ippool, upf, session); (err != nil) != tt.wantErr {
 				t.Errorf("parsePDI() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/pfcpiface/parse_pdr_test.go
+++ b/pfcpiface/parse_pdr_test.go
@@ -122,7 +122,7 @@ func Test_parsePDR(t *testing.T) {
 			mockPDR := &Pdr{}
 			mockIPPool, _ := NewIPPool("10.0.0.0")
 
-			session := &PFCPSession{localSEID: 1}
+			session := &PFCPSession{localSEID: FSEID}
 
 			err := mockPDR.parsePDR(scenario.input, mockMapPFD, mockIPPool, upf, session)
 			require.NoError(t, err)
@@ -164,7 +164,7 @@ func TestParsePDRShouldError(t *testing.T) {
 			mockPDR := &Pdr{}
 			mockIPPool, _ := NewIPPool("10.0.0.0")
 
-			session := &PFCPSession{localSEID: 1}
+			session := &PFCPSession{localSEID: FSEID}
 
 			err := mockPDR.parsePDR(scenario.input, mockMapPFD, mockIPPool, upf, session)
 			require.Error(t, err)

--- a/pfcpiface/parse_pdr_test.go
+++ b/pfcpiface/parse_pdr_test.go
@@ -553,6 +553,7 @@ func Test_portRange_Width(t *testing.T) {
 
 func Test_pdr_parseSDFFilter(t *testing.T) {
 	ueAddress := "17.0.0.1"
+	session := &PFCPSession{localSEID: 1}
 
 	newFilter := func(flowDesc string) *ie.IE {
 		return ie.NewSDFFilter(flowDesc, "", "", "", 1)
@@ -570,6 +571,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 to assigned 80-400"),
 			direction: core,
 			wantAppFilter: ApplicationFilter{
+				FilterID :1,
 				SrcIP:        ip2int(net.ParseIP("192.168.1.1")),
 				DstIP:        ip2int(net.ParseIP(ueAddress)),
 				SrcPortRange: NewRangeMatchPortRange(80, 400),
@@ -586,6 +588,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 to assigned 80-400"),
 			direction: access,
 			wantAppFilter: ApplicationFilter{
+				FilterID :1,
 				SrcIP:        ip2int(net.ParseIP(ueAddress)),
 				DstIP:        ip2int(net.ParseIP("192.168.1.1")),
 				SrcPortRange: newWildcardPortRange(),
@@ -602,6 +605,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 80-400 to assigned"),
 			direction: core,
 			wantAppFilter: ApplicationFilter{
+				FilterID :1,
 				SrcIP:        ip2int(net.ParseIP("192.168.1.1")),
 				DstIP:        ip2int(net.ParseIP(ueAddress)),
 				SrcPortRange: NewRangeMatchPortRange(80, 400),
@@ -618,6 +622,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 80-400 to assigned"),
 			direction: access,
 			wantAppFilter: ApplicationFilter{
+				FilterID :1,
 				SrcIP:        ip2int(net.ParseIP(ueAddress)),
 				DstIP:        ip2int(net.ParseIP("192.168.1.1")),
 				SrcPortRange: newWildcardPortRange(),
@@ -646,7 +651,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 				UeAddress: ip2int(net.ParseIP("17.0.0.1")),
 				SrcIface:  tt.direction,
 			}
-			if err := p.parseSDFFilter(tt.sdfIE); (err != nil) != tt.wantErr {
+			if err := p.parseSDFFilter(tt.sdfIE, session); (err != nil) != tt.wantErr {
 				t.Errorf("parseSDFFilter() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/pfcpiface/parse_pdr_test.go
+++ b/pfcpiface/parse_pdr_test.go
@@ -571,7 +571,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 to assigned 80-400"),
 			direction: core,
 			wantAppFilter: ApplicationFilter{
-				FilterID :1,
+				FilterID:     1,
 				SrcIP:        ip2int(net.ParseIP("192.168.1.1")),
 				DstIP:        ip2int(net.ParseIP(ueAddress)),
 				SrcPortRange: NewRangeMatchPortRange(80, 400),
@@ -588,7 +588,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 to assigned 80-400"),
 			direction: access,
 			wantAppFilter: ApplicationFilter{
-				FilterID :1,
+				FilterID:     1,
 				SrcIP:        ip2int(net.ParseIP(ueAddress)),
 				DstIP:        ip2int(net.ParseIP("192.168.1.1")),
 				SrcPortRange: newWildcardPortRange(),
@@ -605,7 +605,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 80-400 to assigned"),
 			direction: core,
 			wantAppFilter: ApplicationFilter{
-				FilterID :1,
+				FilterID:     1,
 				SrcIP:        ip2int(net.ParseIP("192.168.1.1")),
 				DstIP:        ip2int(net.ParseIP(ueAddress)),
 				SrcPortRange: NewRangeMatchPortRange(80, 400),
@@ -622,7 +622,7 @@ func Test_pdr_parseSDFFilter(t *testing.T) {
 			sdfIE:     newFilter("permit out udp from 192.168.1.1/32 80-400 to assigned"),
 			direction: access,
 			wantAppFilter: ApplicationFilter{
-				FilterID :1,
+				FilterID:     1,
 				SrcIP:        ip2int(net.ParseIP(ueAddress)),
 				DstIP:        ip2int(net.ParseIP("192.168.1.1")),
 				SrcPortRange: newWildcardPortRange(),

--- a/pfcpiface/session_pdr.go
+++ b/pfcpiface/session_pdr.go
@@ -49,6 +49,17 @@ func findChoosedPdr(session *PFCPSession, chooseID uint8) *Pdr {
 	return nil
 }
 
+func findSDFFilter(session *PFCPSession, filterID uint32) *ApplicationFilter {
+	log.Debugf("Find associated SDF filter on session's PDRs")
+
+	for _, pdr := range session.Pdrs {
+		if pdr.AppFilter.FilterID == filterID {
+			return &pdr.AppFilter
+		}
+	}
+	return nil
+}
+
 func addPdrInfo(msg *message.SessionEstablishmentResponse,
 	session *PFCPSession) {
 	log.Info("Add PDRs with UPF alloc teids/IPs to Establishment response")
@@ -124,3 +135,4 @@ func (s *PFCPSession) RemovePDR(id uint32) (*Pdr, error) {
 
 	return nil, ErrNotFound("PDR")
 }
+

--- a/pfcpiface/session_pdr.go
+++ b/pfcpiface/session_pdr.go
@@ -124,4 +124,3 @@ func (s *PFCPSession) RemovePDR(id uint32) (*Pdr, error) {
 
 	return nil, ErrNotFound("PDR")
 }
-

--- a/pfcpiface/session_pdr.go
+++ b/pfcpiface/session_pdr.go
@@ -135,4 +135,3 @@ func (s *PFCPSession) RemovePDR(id uint32) (*Pdr, error) {
 
 	return nil, ErrNotFound("PDR")
 }
-

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -181,4 +181,3 @@ func NewUPF(conf *Conf, fp Datapath) *Upf {
 
 	return u
 }
-

--- a/pfcpiface/upf.go
+++ b/pfcpiface/upf.go
@@ -4,6 +4,7 @@
 package pfcpiface
 
 import (
+	"math"
 	"net"
 	"time"
 
@@ -43,12 +44,15 @@ type Upf struct {
 	AccessIP          net.IP
 	CoreIP            net.IP
 	NodeID            string
-	ippool            *IPPool
-	peers             []string
-	dnn               string
-	ReportNotifyChan  chan uint64
-	sliceInfo         *SliceInfo
-	readTimeout       time.Duration
+
+	ippool        *IPPool
+	teidAllocator *IDAllocator
+
+	peers            []string
+	dnn              string
+	ReportNotifyChan chan uint64
+	sliceInfo        *SliceInfo
+	readTimeout      time.Duration
 
 	Datapath
 	maxReqRetries uint8
@@ -58,7 +62,6 @@ type Upf struct {
 }
 
 // to be replaced with go-pfcp structs
-
 // Don't change these values.
 const (
 	tunnelGTPUPort = 2152
@@ -172,7 +175,10 @@ func NewUPF(conf *Conf, fp Datapath) *Upf {
 		}
 	}
 
+	u.teidAllocator = NewIDAllocator(1, math.MaxUint32)
+
 	u.Datapath.SetUpfInfo(u, conf)
 
 	return u
 }
+

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -142,4 +142,3 @@ func GetSliceTCMeterIndex(sliceID uint8, TC uint8) (int64, error) {
 
 	return int64((sliceID << 2) + (TC & 0b11)), nil
 }
-

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -20,7 +20,6 @@ func Set(b, flag Bits) Bits { return b | flag }
 // func Clear(b, flag Bits) Bits  { return b &^ flag }
 // func Toggle(b, flag Bits) Bits { return b ^ flag }
 // func Has(b, flag Bits) bool { return b&flag != 0 }
-
 func setUeipFeature(features ...uint8) {
 	if len(features) >= 3 {
 		features[2] = features[2] | 0x04
@@ -31,6 +30,10 @@ func setEndMarkerFeature(features ...uint8) {
 	if len(features) >= 2 {
 		features[1] = features[1] | 0x01
 	}
+}
+
+func setTeidAllocFeature(features ...uint8) {
+	features[0] = features[0] | 0x10
 }
 
 func has2ndBit(f uint8) bool {
@@ -139,3 +142,4 @@ func GetSliceTCMeterIndex(sliceID uint8, TC uint8) (int64, error) {
 
 	return int64((sliceID << 2) + (TC & 0b11)), nil
 }
+


### PR DESCRIPTION
- Adds TEID allocator in pfcpiface module
- Implementing parsing of bidirectional SDF from PDRs in session create and modification messages
- Allocates TEID and IPv4 if SMF requests UPF to do 