### PR TITLE
URR handling

### DIFF
--- a/pfcpiface/parse_urr.go
+++ b/pfcpiface/parse_urr.go
@@ -1,0 +1,101 @@
+package pfcpiface
+
+import (
+	"fmt"
+
+	"github.com/wmnsk/go-pfcp/ie"
+)
+
+type Urr struct {
+	UrrID          uint32
+	CtrID          uint32
+	PdrID          uint32
+	FseidIP        uint32
+	MeasureMethod  uint8
+	ReportOpen     bool
+	Trigger        ReportTrigger
+	LocalThreshold uint64
+	VolThreshold   VolumeData
+	VolQuota       VolumeData
+	// local session ID
+	FseID uint64
+}
+
+type ReportTrigger struct {
+	Flags uint16
+}
+
+type VolumeData struct {
+	Flags       uint8
+	TotalVol    uint64
+	UplinkVol   uint64
+	DownlinkVol uint64
+}
+
+func (r *ReportTrigger) isVOLTHSet() bool {
+	u8 := uint8(r.Flags >> 8)
+	return has2ndBit(u8)
+}
+func (r *ReportTrigger) isVOLQUSet() bool {
+	u8 := uint8(r.Flags)
+	return has1stBit(u8)
+}
+
+func (u *Urr) String() string {
+	return fmt.Sprintf("URR(id=%v, ctrID=%v, pdrID=%v, F-SEID IPv4=%v, measureMethod=%v, "+
+		"reportOpen=%v, trigger=%v, localThreshold=%v, volThreshold=%v, volQuota=%v)",
+		u.UrrID, u.CtrID, u.PdrID, u.FseidIP, u.MeasureMethod, u.ReportOpen, u.Trigger,
+		u.LocalThreshold, u.VolThreshold, u.VolQuota)
+}
+
+func (u *Urr) parseURR(ie1 *ie.IE, seid uint64) error {
+	log.Info("Parse Create URR")
+	volumeThresh := VolumeData{}
+	volumeQuota := VolumeData{}
+
+	urrID, err := ie1.URRID()
+	if err != nil {
+		log.Error("Could not read urrID!")
+		return err
+	}
+
+	measureMethod, err := ie1.MeasurementMethod()
+	if err != nil {
+		log.Error("Could not read Measurement method!")
+		return err
+	}
+
+	trigger, err := ie1.ReportingTriggers()
+	if err != nil {
+		log.Error("Could not read Reporting triggers!")
+		return err
+	}
+
+	reportTrigger := ReportTrigger{Flags: trigger}
+	volThreshField, err := ie1.VolumeThreshold()
+	if err == nil {
+		volumeThresh.Flags = volThreshField.Flags
+		volumeThresh.TotalVol = volThreshField.TotalVolume
+		volumeThresh.UplinkVol = volThreshField.UplinkVolume
+		volumeThresh.DownlinkVol = volThreshField.DownlinkVolume
+	}
+
+	volQuotaField, err := ie1.VolumeQuota()
+	if err == nil {
+		volumeQuota.Flags = volQuotaField.Flags
+		volumeQuota.TotalVol = volQuotaField.TotalVolume
+		volumeQuota.UplinkVol = volQuotaField.UplinkVolume
+		volumeQuota.DownlinkVol = volQuotaField.DownlinkVolume
+	}
+
+	u.UrrID = uint32(urrID)
+	u.MeasureMethod = measureMethod
+	u.Trigger = reportTrigger
+	u.ReportOpen = true
+	u.VolThreshold = volumeThresh
+	u.LocalThreshold = volumeThresh.TotalVol
+	u.VolQuota = volumeQuota
+	u.FseID = seid
+
+	return nil
+}

--- a/pfcpiface/parse_urr_test.go
+++ b/pfcpiface/parse_urr_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022-present Open Networking Foundation
+
+package pfcpiface
+
+import (
+	"testing"
+
+	pfcpsimLib "github.com/omec-project/pfcpsim/pkg/pfcpsim/session"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wmnsk/go-pfcp/ie"
+)
+
+type urrTestCase struct {
+	input       *ie.IE
+	expected    *Urr
+	description string
+}
+
+func TestParseURR(t *testing.T) {
+	FSEID := uint64(100)
+
+	for _, scenario := range []urrTestCase{
+		{
+			input: pfcpsimLib.NewURRBuilder().
+				WithID(999).
+				WithMethod(pfcpsimLib.IEMethod(create)).
+				WithMeasurementMethodVolume(1).
+				WithVolThresholdFlags(7).
+				WithVolThresholdTotalVol(1000).
+				WithVolThresholdUplinkVol(200).
+				WithVolThresholdDownlinkVol(800).
+				WithVolQuotaFlags(3).
+				WithVolQuotaTotalVol(700).
+				WithVolQuotaUplinkVol(300).
+				WithVolQuotaDownlinkVol(400).
+				WithTriggers(2).
+				Build(),
+			expected: &Urr{
+				UrrID: 999,
+				MeasureMethod: 2,
+				ReportOpen: true,
+				Trigger: ReportTrigger{
+					Flags: 2,
+				},
+				LocalThreshold: 1000,
+				VolThreshold: VolumeData{
+					Flags: 7,
+					TotalVol: 1000,
+					UplinkVol: 200,
+					DownlinkVol: 800,
+				},
+				VolQuota: VolumeData{
+					// only TotalVol and UplinkVol are set
+					Flags: 3,
+					TotalVol: 700,
+					UplinkVol: 300,
+					DownlinkVol: 0,
+				},
+				FseID: FSEID,
+			},
+			description: "Valid Create URR input",
+		},
+		{
+			input: pfcpsimLib.NewURRBuilder().
+				WithID(999).
+				WithMethod(pfcpsimLib.IEMethod(update)).
+				WithMeasurementMethodVolume(1).
+				WithVolThresholdFlags(7).
+				WithVolThresholdTotalVol(1000).
+				WithVolThresholdUplinkVol(200).
+				WithVolThresholdDownlinkVol(800).
+				WithVolQuotaFlags(3).
+				WithVolQuotaTotalVol(700).
+				WithVolQuotaUplinkVol(300).
+				WithVolQuotaDownlinkVol(400).
+				WithTriggers(2).
+				Build(),
+			expected: &Urr{
+				UrrID: 999,
+				MeasureMethod: 2,
+				ReportOpen: true,
+				Trigger: ReportTrigger{
+					Flags: 2,
+				},
+				LocalThreshold: 1000,
+				VolThreshold: VolumeData{
+					Flags: 7,
+					TotalVol: 1000,
+					UplinkVol: 200,
+					DownlinkVol: 800,
+				},
+				VolQuota: VolumeData{
+					// only TotalVol and UplinkVol are set
+					Flags: 3,
+					TotalVol: 700,
+					UplinkVol: 300,
+					DownlinkVol: 0,
+				},
+				FseID: FSEID,
+			},
+			description: "Valid Update URR input",
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			mockURR := &Urr{}
+
+			err := mockURR.parseURR(scenario.input, FSEID)
+			require.NoError(t, err)
+
+			assert.Equal(t, scenario.expected, mockURR)
+		})
+	}
+}
+
+func TestParseURRShouldError(t *testing.T) {
+	FSEID := uint64(100)
+
+	for _, scenario := range []urrTestCase{
+		{
+			input: ie.NewCreateURR(
+				ie.NewReportingTriggers(2),
+			),
+			expected:    &Urr{},
+			description: "Invalid URR input: no URR ID provided",
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			mockURR := &Urr{}
+
+			err := mockURR.parseURR(scenario.input, FSEID)
+			require.Error(t, err)
+
+			assert.Equal(t, scenario.expected, mockURR)
+		})
+	}
+}

--- a/pfcpiface/session_urr.go
+++ b/pfcpiface/session_urr.go
@@ -1,0 +1,28 @@
+package pfcpiface
+
+// CreateURR appends urr to existing list of URRs in the session.
+func (s *PFCPSession) CreateURR(u Urr) {
+	s.Urrs = append(s.Urrs, u)
+}
+
+func (s *PFCPSession) UpdateURR(u Urr) error {
+	for idx, v := range s.Urrs {
+		if v.UrrID == u.UrrID {
+			s.Urrs[idx] = u
+			return nil
+		}
+	}
+
+	return ErrNotFound("URR")
+}
+
+func (s *PFCPSession) RemoveURR(id uint32) (*Urr, error) {
+	for idx, v := range s.Urrs {
+		if v.UrrID == id {
+			s.Urrs = append(s.Urrs[:idx], s.Urrs[idx+1:]...)
+			return &v, nil
+		}
+	}
+
+	return nil, ErrNotFound("URR")
+}

--- a/pfcpiface/sessions.go
+++ b/pfcpiface/sessions.go
@@ -13,6 +13,7 @@ type PacketForwardingRules struct {
 	Pdrs []Pdr
 	Fars []Far
 	Qers []Qer
+	Urrs []Urr
 }
 
 // PFCPSession implements one PFCP session.
@@ -27,7 +28,7 @@ type PFCPSession struct {
 }
 
 func (p PacketForwardingRules) String() string {
-	return fmt.Sprintf("PDRs=%v, FARs=%v, QERs=%v", p.Pdrs, p.Fars, p.Qers)
+	return fmt.Sprintf("PDRs=%v, FARs=%v, QERs=%v, URRs=%v", p.Pdrs, p.Fars, p.Qers, p.Urrs)
 }
 
 // NewPFCPSession allocates an session with ID.
@@ -46,6 +47,7 @@ func (pConn *PFCPConn) NewPFCPSession(rseid uint64) (PFCPSession, bool) {
 				Pdrs: make([]Pdr, 0, MaxItems),
 				Fars: make([]Far, 0, MaxItems),
 				Qers: make([]Qer, 0, MaxItems),
+				Urrs: make([]Urr, 0, MaxItems),
 			},
 		}
 		s.metrics = metrics.NewSession(pConn.nodeID.remote)

--- a/pfcpiface/utils.go
+++ b/pfcpiface/utils.go
@@ -36,6 +36,10 @@ func setTeidAllocFeature(features ...uint8) {
 	features[0] = features[0] | 0x10
 }
 
+func has1stBit(f uint8) bool {
+	return (f & 0x01) == 1
+}
+
 func has2ndBit(f uint8) bool {
 	return (f&0x02)>>1 == 1
 }


### PR DESCRIPTION
Update pfcpiface to parse URRs creates/updates/deletes requests from SMF. The URRs are cached in the local PFCP sessions.


---

Run unit tests

```
░▒▓  │  ~/workspace/github/omec-upf/pfcpiface │ on   master !4 ▓▒░ go test ./...                                                                                                    ░▒▓ PIPE ✘ │ at 09:39:07  ▓▒░
ok      github.com/ardzoht/omec-upf/pfcpiface   14.944s
?       github.com/ardzoht/omec-upf/pfcpiface/bess_pb   [no test files]
?       github.com/ardzoht/omec-upf/pfcpiface/bess_pb/ports     [no test files]
ok      github.com/ardzoht/omec-upf/pfcpiface/metrics   (cached)
```